### PR TITLE
fix(staff): replace uniform-beat position helpers with buf-aware versions

### DIFF
--- a/lua/tablature/chord_mode.lua
+++ b/lua/tablature/chord_mode.lua
@@ -38,7 +38,11 @@ local function draw_chord_preview(bufnr, ctx_fn)
 	local shape = chord_mode.shapes[shape_name]
 	local voicing = staff.apply_offset(shape, chord_mode.offset)
 	local num_strings = #state.tuning.strings
-	local col = staff.buf_position_to_col(state.bufnr, state.staff_top, ctx.pos)
+	local col = staff.position_to_col(state.bufnr, state.staff_top, ctx.pos)
+	if not col then
+		vim.notify("Column not found", 4)
+		return
+	end
 	for string_idx = 0, num_strings - 1 do
 		local v = voicing[num_strings - string_idx] or "-"
 		local row = ctx.staff_top + string_idx

--- a/lua/tablature/mode.lua
+++ b/lua/tablature/mode.lua
@@ -84,8 +84,9 @@ local function get_cursor_context()
 	end
 
 	local string_idx = row - top -- 0-indexed from top
-	local pos = staff.buf_col_to_position(state.bufnr, top, col)
+	local pos = staff.col_to_position(state.bufnr, top, col)
 	if not pos then
+		vim.notify("tablature: Failed to calculate position", 4)
 		return nil
 	end
 
@@ -120,18 +121,22 @@ local function move_to(ctx, new_pos, new_string_idx)
 	si = math.max(0, math.min(num_strings - 1, si))
 
 	local new_row = ctx.staff_top + si + 1 -- 1-indexed for nvim_win_set_cursor
-	local new_col = staff.buf_position_to_col(state.bufnr, state.staff_top, new_pos)
+	local new_col = staff.position_to_col(state.bufnr, state.staff_top, new_pos)
+	if not new_col then
+		vim.notify("tablature: Could not calculate new column position", 4)
+		return
+	end
 
 	vim.api.nvim_win_set_cursor(0, { new_row, new_col })
 
 	-- Update highlights: highlight full measure width
 	local measure_start_pos = { measure = new_pos.measure, beat = 0 }
-	hl.highlight_beat_column(
-		state.bufnr,
-		ctx.staff_top,
-		staff.buf_position_to_col(state.bufnr, state.staff_top, measure_start_pos),
-		beats * 3
-	)
+	local measure_col = staff.position_to_col(state.bufnr, state.staff_top, measure_start_pos)
+	if not measure_col then
+		vim.notify("tablature: Could not calculate measure column position", 4)
+		return
+	end
+	hl.highlight_beat_column(state.bufnr, ctx.staff_top, measure_col, beats * 3)
 	hl.show_mode_indicator(state.bufnr, ctx.staff_top, new_pos)
 end
 
@@ -146,7 +151,11 @@ local function write_fret(char)
 	end
 
 	-- Check if the current cell already has a digit (double-digit fret case)
-	local col = staff.buf_position_to_col(state.bufnr, state.staff_top, ctx.pos)
+	local col = staff.position_to_col(state.bufnr, state.staff_top, ctx.pos)
+	if not col then
+		vim.notify("tablature: Column not found", 4)
+		return
+	end
 	local line = vim.api.nvim_buf_get_lines(
 		state.bufnr,
 		ctx.staff_top + ctx.string_idx,
@@ -312,13 +321,20 @@ function M.enter()
 
 	-- Initial highlight + indicator
 	local col = cursor[2]
-	local pos = staff.buf_col_to_position(bufnr, top, col)
-	if pos then
-		local measure_beats = staff.get_measure_beats(bufnr, top, pos.measure)
-		local measure_start = { measure = pos.measure, beat = 0 }
-		hl.highlight_beat_column(bufnr, top, staff.buf_position_to_col(bufnr, top, measure_start), measure_beats * 3)
-		hl.show_mode_indicator(bufnr, top, pos)
+	local pos = staff.col_to_position(bufnr, top, col)
+	if not pos then
+		vim.notify("tablature: Failed to calculate position", 4)
+		return
 	end
+	local measure_beats = staff.get_measure_beats(bufnr, top, pos.measure)
+	local measure_start = { measure = pos.measure, beat = 0 }
+	local measure_col = staff.position_to_col(bufnr, top, measure_start)
+	if not measure_col then
+		vim.notify("tablature: Could not calculate measure column", 4)
+		return
+	end
+	hl.highlight_beat_column(bufnr, top, measure_col, measure_beats * 3)
+	hl.show_mode_indicator(bufnr, top, pos)
 	hl.show_tab_legend(bufnr, top)
 
 	-- Auto-exit if cursor leaves the buffer
@@ -460,7 +476,11 @@ function M.set_beats()
 			-- Clamp cursor beat in case measure shrank
 			local clamped_beat = math.min(ctx.pos.beat, new_beats - 1)
 			local new_pos = { measure = measure_idx, beat = clamped_beat }
-			local new_col = staff.buf_position_to_col(bufnr, staff_top, new_pos)
+			local new_col = staff.position_to_col(bufnr, staff_top, new_pos)
+			if not new_col then
+				vim.notify("tablature: Failed to calculate new column", 4)
+				return
+			end
 			vim.api.nvim_win_set_cursor(0, { ctx.staff_top + ctx.string_idx + 1, new_col })
 		end)
 	end)

--- a/lua/tablature/staff.lua
+++ b/lua/tablature/staff.lua
@@ -163,56 +163,6 @@ function M.find_staff_top(bufnr, row)
 	return top
 end
 
---- Given a cursor column, compute which measure and beat slot the cursor is in.
---- Returns { measure, beat } both 0-indexed, or nil if not in a grid cell.
---- Assumes all measures have the same beat count (cfg.beats). For variable-beat
---- staffs use buf_col_to_position instead.
----@param col integer   0-indexed column
----@return tablature.staff.position|nil
-function M.col_to_position(col)
-	local cfg = config.options
-	local beats = cfg.beats
-	local sep_width = cfg.measure_sep:len()
-	local label_width = state.label_width
-	local content_start = label_width + sep_width
-
-	if col < content_start then
-		return nil
-	end
-
-	local offset = col - content_start
-	local cell_width = beats * 3 + sep_width -- each measure: beats*3 filler chars + trailing sep
-
-	local measure = math.floor(offset / cell_width)
-	if measure >= cfg.default_measures then
-		return nil
-	end
-	local char_pos = offset % cell_width
-
-	-- If cursor is on the measure separator, bail
-	if char_pos >= beats * 3 then
-		return nil
-	end
-
-	local beat = math.floor(char_pos / 3)
-	return { measure = measure, beat = beat }
-end
-
---- Given a position {measure, beat}, return the 0-indexed column.
---- Assumes all measures have the same beat count (cfg.beats). For variable-beat
---- staffs use buf_position_to_col instead.
----@param pos tablature.staff.position
----@return integer
-function M.position_to_col(pos)
-	local cfg = config.options
-	local beats = cfg.beats
-	local label_width = state.label_width
-	local sep_width = cfg.measure_sep:len()
-	local cell_width = beats * 3 + sep_width
-
-	return label_width + sep_width + pos.measure * cell_width + pos.beat * 3
-end
-
 --- Write a character at (string_idx 0-indexed from top, measure, beat, sub)
 --- into the buffer. Ensures all string lines stay consistent.
 ---@param bufnr integer
@@ -222,7 +172,11 @@ end
 ---@param char string  single character to write
 function M.write_char(bufnr, staff_top, string_idx, pos, char)
 	local row = staff_top + string_idx
-	local col = M.position_to_col(pos)
+	local col = M.position_to_col(bufnr, staff_top, pos)
+	if not col then
+		vim.notify("tablature: Failed to calculate column", 4)
+		return
+	end
 	local line = vim.api.nvim_buf_get_lines(bufnr, row, row + 1, false)[1]
 	if not line then
 		return
@@ -248,7 +202,11 @@ end
 ---@param tens string   first digit character
 ---@param ones string   second digit character
 function M.write_double_digit(bufnr, staff_top, string_idx, pos, tens, ones)
-	local col = M.position_to_col(pos)
+	local col = M.position_to_col(bufnr, staff_top, pos)
+	if not col then
+		vim.notify("tablature: Failed to calculate column", 4)
+		return
+	end
 
 	local row = staff_top + string_idx
 	local line = vim.api.nvim_buf_get_lines(bufnr, row, row + 1, false)[1]
@@ -334,13 +292,12 @@ function M.get_measure_beats(bufnr, staff_top, measure_idx)
 	return math.floor((sp - pos) / 3)
 end
 
---- Convert a position to a 0-indexed column by scanning the actual buffer content.
---- Unlike position_to_col, this handles measures with different beat counts.
+--- Convert a position to a 0-indexed column by scanning the buffer content.
 ---@param bufnr integer
 ---@param staff_top integer  0-indexed row of top staff line
 ---@param pos tablature.staff.position
----@return integer
-function M.buf_position_to_col(bufnr, staff_top, pos)
+---@return integer|nil
+function M.position_to_col(bufnr, staff_top, pos)
 	local cfg = config.options
 	local sep = cfg.measure_sep
 	local sep_width = #sep
@@ -348,25 +305,26 @@ function M.buf_position_to_col(bufnr, staff_top, pos)
 
 	local line = vim.api.nvim_buf_get_lines(bufnr, staff_top, staff_top + 1, false)[1]
 	if not line then
-		return M.position_to_col(pos)
+		vim.notify("tablature: Staff lines were not found in buffer " .. bufnr, 4)
+		return nil
 	end
 
 	-- Walk pos.measure measures to find the start of the target measure
 	local scan = find_measure_start(line, pos.measure, label_width, sep, sep_width)
 	if not scan then
-		return M.position_to_col(pos)
+		vim.notify("tablature: Could not find measure start at line " .. line, 4)
+		return nil
 	end
 	-- scan is the 1-indexed start of the target measure; add beat offset
 	return (scan - 1) + pos.beat * 3
 end
 
---- Convert a 0-indexed column to a position by scanning the actual buffer content.
---- Unlike col_to_position, this handles measures with different beat counts.
+--- Convert a 0-indexed column to a position by scanning the buffer content.
 ---@param bufnr integer
 ---@param staff_top integer  0-indexed row of top staff line
----@param col integer  0-indexed column
+---@param col integer|nil  0-indexed column
 ---@return tablature.staff.position|nil
-function M.buf_col_to_position(bufnr, staff_top, col)
+function M.col_to_position(bufnr, staff_top, col)
 	local cfg = config.options
 	local sep = cfg.measure_sep
 	local sep_width = #sep
@@ -374,7 +332,8 @@ function M.buf_col_to_position(bufnr, staff_top, col)
 
 	local line = vim.api.nvim_buf_get_lines(bufnr, staff_top, staff_top + 1, false)[1]
 	if not line then
-		return M.col_to_position(col)
+		vim.notify("tablature: Staff lines were not found in buffer " .. bufnr, 4)
+		return nil
 	end
 
 	local content_start = label_width + sep_width -- 0-indexed

--- a/spec/staff_divisions_spec.lua
+++ b/spec/staff_divisions_spec.lua
@@ -88,19 +88,13 @@ describe("staff.set_measure_beats", function()
 		-- Expand measure 0 from 4 to 8 beats
 		staff.set_measure_beats(bufnr, top, 0, 8)
 		-- The note should still be at the same position
-		local col = staff.buf_position_to_col(bufnr, top, pos)
+		local col = staff.position_to_col(bufnr, top, pos)
 		local line = buf_lines(bufnr)[1]
 		assert.are.equal("5", line:sub(col + 1, col + 1))
 	end)
 end)
 
-describe("staff.buf_position_to_col", function()
-	it("matches position_to_col for uniform-beat staffs", function()
-		local bufnr, top = make_staff()
-		local pos = { measure = 0, beat = 2 }
-		assert.are.equal(staff.position_to_col(pos), staff.buf_position_to_col(bufnr, top, pos))
-	end)
-
+describe("staff.position_to_col", function()
 	it("accounts for a wider measure 0 when computing measure 1 column", function()
 		local bufnr, top = make_staff()
 		staff.set_measure_beats(bufnr, top, 0, 8)
@@ -108,17 +102,17 @@ describe("staff.buf_position_to_col", function()
 		-- label(1) + sep(1) + 1 measure * (4*3+1) = 2 + 13 = 15
 		local uniform_col = staff.position_to_col({ measure = 1, beat = 0 })
 		-- With beats=8 for measure 0: col should be larger
-		local buf_col = staff.buf_position_to_col(bufnr, top, { measure = 1, beat = 0 })
+		local buf_col = staff.position_to_col(bufnr, top, { measure = 1, beat = 0 })
 		assert.is_true(buf_col > uniform_col)
 	end)
 end)
 
-describe("staff.buf_col_to_position", function()
-	it("round-trips with buf_position_to_col", function()
+describe("staff.col_to_position", function()
+	it("round-trips with position_to_col", function()
 		local bufnr, top = make_staff()
 		local pos = { measure = 1, beat = 3 }
-		local col = staff.buf_position_to_col(bufnr, top, pos)
-		local back = staff.buf_col_to_position(bufnr, top, col)
+		local col = staff.position_to_col(bufnr, top, pos)
+		local back = staff.col_to_position(bufnr, top, col)
 		assert.are.equal(pos.measure, back.measure)
 		assert.are.equal(pos.beat, back.beat)
 	end)
@@ -127,8 +121,8 @@ describe("staff.buf_col_to_position", function()
 		local bufnr, top = make_staff()
 		staff.set_measure_beats(bufnr, top, 0, 8)
 		local pos = { measure = 1, beat = 1 }
-		local col = staff.buf_position_to_col(bufnr, top, pos)
-		local back = staff.buf_col_to_position(bufnr, top, col)
+		local col = staff.position_to_col(bufnr, top, pos)
+		local back = staff.col_to_position(bufnr, top, col)
 		assert.are.equal(pos.measure, back.measure)
 		assert.are.equal(pos.beat, back.beat)
 	end)
@@ -137,6 +131,6 @@ describe("staff.buf_col_to_position", function()
 		local bufnr, top = make_staff()
 		-- The separator after the label is at column label_width (0-indexed)
 		local sep_col = state.label_width
-		assert.is_nil(staff.buf_col_to_position(bufnr, top, sep_col))
+		assert.is_nil(staff.col_to_position(bufnr, top, sep_col))
 	end)
 end)


### PR DESCRIPTION
## Summary

- Removes the old `col_to_position` / `position_to_col` helpers that assumed all measures had the same beat count (`cfg.beats`)
- Replaces them with buf-scanning equivalents that read actual measure widths from the buffer
- Fixes insertion into any measure that follows a measure whose beat count was changed with `set_beats`

Closes #16